### PR TITLE
Adding a basic Package-Requires header.

### DIFF
--- a/nrepl-eval-sexp-fu.el
+++ b/nrepl-eval-sexp-fu.el
@@ -5,6 +5,7 @@
 ;; Modified to add nrepl support by Sam Aaron <samaaron@gmail.com>
 
 ;; Keywords: lisp, highlight, convenience
+;; Package-Requires: ((highlight "0.0.0") (smartparens "0.0.0") (thingatpt "0.0.0")
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Installing this package standalone from Mepla fails for me, because I haven't made the switch to smartparens yet. Adding in this Package-Requires header will ensure other people get the required dependencies automatically. :-)
