### PR TITLE
Patching a range bug in nesf-live-whitespace-at-point-p.

### DIFF
--- a/nrepl-eval-sexp-fu.el
+++ b/nrepl-eval-sexp-fu.el
@@ -5,7 +5,7 @@
 ;; Modified to add nrepl support by Sam Aaron <samaaron@gmail.com>
 
 ;; Keywords: lisp, highlight, convenience
-;; Package-Requires: ((highlight "0.0.0") (smartparens "0.0.0") (thingatpt "0.0.0")
+;; Package-Requires: ((highlight "0.0.0") (smartparens "0.0.0") (thingatpt "0.0.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nrepl-eval-sexp-fu.el
+++ b/nrepl-eval-sexp-fu.el
@@ -132,7 +132,9 @@
 
 (defun nesf-live-whitespace-at-point-p ()
   "Returns true if the char at point is whitespace"
-  (string-match "[ \n\t]" (buffer-substring (point) (+ 1 (point)))))
+  (let ((char (char-after (point))))
+    (or (equal char nil)
+	(equal (char-syntax char) ?-))))
 
 (defun nesf-hl-highlight-bounds (bounds face buf)
   (with-current-buffer buf


### PR DESCRIPTION
`nesf-live-whitespace-at-point-p` throws an error if the point is at the end of the file, because `(+ 1 (point))` exceeds `(point-max)`.
So calling `cider-eval-expression-at-point` throws an error if the expression is the last thing in the file (with no trailing whitespace).

Whilst this patch works, I'm not 100% sure this is the best way to fix it, because now the comment string isn't strictly true - it's testing for whitespace or end-of-file. But I'm not sure it's worth spinning out into a separate predicate & test. Up to you. I'll resubmit if you have a preferred approach.

(Oh, one small nice thing about using `char-syntax` instead of `string-match` is that it respects the current mode's syntax table's definition of whitespace.)
